### PR TITLE
Adding CONTRIBUTING.md and definition of chairing role

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! We are glad that you want to contribute to the AI Alignment Working Gro
 
 Please review the [CHAOSS CONTRIBUTING.md](http://github.com/chaoss/community/CONTRIBUTING.md) for general ways to contribute to CHAOSS; this document provides context specific to the AI Alignment working group.
 
-Join the [AI Alignment Slack Channel](https://chaoss.community/kb-getting-started/) #wg-ai-alignment channel or submit pull requests if you'd like to reach out to the community!
+Join the [AI Alignment Slack Channel](https://chaoss-workspace.slack.com/archives/C09GR3W4K4J) #wg-ai-alignment channel or submit pull requests if you'd like to reach out to the community!
 
 ## Ways to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing Guide
+
+Welcome! We are glad that you want to contribute to the AI Alignment Working Group.
+
+Please review the [CHAOSS CONTRIBUTING.md](http://github.com/chaoss/community/CONTRIBUTING.md) for general ways to contribute to CHAOSS; this document provides context specific to the AI Alignment working group.
+
+Join the [AI Alignment Slack Channel](https://chaoss.community/kb-getting-started/) #wg-ai-alignment channel or submit pull requests if you'd like to reach out to the community!
+
+## Ways to Contribute
+
+We welcome many different types of contributions including:
+
+* Metrics definitions
+* Issue Triage
+* Speaking about our work at conferences
+* Inviting others to join (especially perspectives not represented here)
+* Writing about our work (blogging, posting)
+* Sharing relevant news articles, posts, research (etc) anything that helps us in the context of open source, AI and alignment.  This can be done in Slack or via the issue template for links.
+
+## Working Group Chairs
+
+There are people you can count on to keep things moving, and to help unblock you or answer questions if you are unsure.
+
+Your current co-chairs are:
+
+- ![emmairwin](https://github.com/emmairwin.png?size=20) [Emma Irwin](https://github.com/emmairwin)
+- ![coralineada](https://github.com/coralineada.png?size=20) [Coraline Ada Ehmke](https://github.com/coralineada)
+- ![justwheel](https://github.com/justwheel.png?size=20) [Justin Wheeler](https://github.com/justwheel)
+
+### Chair Primary Role Descriptions
+
+Chairs in the context of CHAOSS are those responsible for the productivity of the group and success of its contributors.  
+
+- Responding to newcomer questions in [chat channel] and on GitHub.
+- Helping select tasks for newcomers or other community members who are unsure of where to start.
+- Reviewing pull requests and tasks.
+- Providing useful feedback in issues.
+- Encouraging and participating in discussions
+- Modelling Code of Conduct expected behaviors and escalating concerns to the Code of Conduct Committee if need be
+- Bridging the group with broader CHAOSS governance efforts (for example promoting elections)
+
+### Working Group Meetings
+- Agendas
+- Facilitation
+
+### How to Become a Co-Chair
+
+If you are interested in supporting this working group through contribution of the co-chair activities- please reach out to any of the current co-chairs. We hope to better define this process in future.
+
+### Review Periods
+
+Once per year, we'll check in with our team members (both _active_ and _on break_) to ensure they are feeling supported, and to check if they will remain active on our team for the coming months. If we do not hear back from members at check-in time, they will be transitioned to an emeritus role.
+
+As of this writing, **the next review period will be May 2027**.
+
+## Developer Certificate of Origin (DCO)
+
+All contributions require a DCO sign-off. Please visit the [DCO Setup](https://chaoss.community/kb/dco-setup/) Knowledge Base article for details.
+
+Sign off each commit with:
+
+```
+git commit -s -m "Your commit message"
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # wg-ai-alignment
 This repo is for the AI Alignment Working Group
 
+What is AI Alignment?
+AI alignment is the effort to design AI systems so their goals, behaviors, and decisions are consistent with human values. In open source, we’re focused on ensuring AI systems understand and respect what we have built, what we know, what we value, and what we expect as  open source communities.
 
-Join the [CHAOSS Slack](https://chaoss.community/kb-getting-started/) #wg-ai-alignment channel or submit pull requests if you'd like to reach out to the community!
+Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information on how to participate and contribute.
+
+


### PR DESCRIPTION
I have proposed a CONTRIBUTING.md to handle questions about the group, but also who the chairs are, accountability etc.

I will be asking @CoralineAda and @justwheel to review this PR since its the first thing we have which has attempted to define the role.  

Note that I used the CHAOSS Inclusive Metric, and specifically the leadership template to think about how we might document  https://chaoss.community/kb/metric-inclusive-leadership/