### PR TITLE
Add Polars AI usage policy

### DIFF
--- a/moderation/README.md
+++ b/moderation/README.md
@@ -51,6 +51,7 @@ This includes:
 * [GDAL AI Policy](https://gdal.org/en/stable/community/ai_tool_policy.html)
 * QGIS ([discusion/proposal](https://github.com/qgis/QGIS-Enhancement-Proposals/blob/master/qep-408-ai-tool-policy.md))
 * [NLNet Labs LLM policy](https://nlnetlabs.nl/llm-policy/)
+* [Polars](https://github.com/pola-rs/polars/blob/main/AI_POLICY.md#ai-usage-policy)
 
 
 ### Organization/Company Policies


### PR DESCRIPTION
Closes #92.

This PR adds Polars AI usage policy to the Current Project AI Policies list.

Preview for your quick ref: https://github.com/omkar-foss/wg-ai-alignment/blob/aea966b6a412886dd2ff3de3d10438aeedaaaaec/moderation/README.md#current-project-ai-policies