### PR TITLE
Add CoMaps, RosarioSIS, GNU Health AI policies

### DIFF
--- a/moderation/README.md
+++ b/moderation/README.md
@@ -54,6 +54,9 @@ This includes:
 * [Polars](https://github.com/pola-rs/polars/blob/main/AI_POLICY.md#ai-usage-policy)
 * [Rust](https://forge.rust-lang.org/policies/llm-usage.html) ([Announcement](https://blog.rust-lang.org/inside-rust/2026/08/05/rust-langrust-is-adopting-an-llm-policy/))
 * [Libfossil](https://fossil.wanderinghorse.net/r/libfossil/doc/trunk/doc/llm.md)
+* [CoMaps](https://codeberg.org/comaps/Governance/src/branch/main/AI_USAGE.md)
+* [RosarioSIS](https://www.rosariosis.org/no-ai-please/)
+* [GNU Health](https://docs.gnuhealth.org/his/techguide/contributing.html#contributing)
 
 ### Organization/Company Policies
 * [Flathub Generative AI policy](https://docs.flathub.org/docs/for-app-authors/requirements#generative-ai-policy)


### PR DESCRIPTION
Resolves #101, #104, #105

This pr adds AI policies for CoMaps, RosarioSIS and GNU Health as per #101, #104, #105 respectively.